### PR TITLE
Reflect gem rename in example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Or install it yourself as:
 ## Usage
 
 ```ruby
-  require 'pairtree' # You'll need to do this in rails, as it won't find it automatically.
+  require 'rpairtree' # You'll need to do this in rails, as it won't find it automatically.
 
   # Initiate a tree
   pairtree = Pairtree.at('./data', :prefix => 'pfx:', :create => true)


### PR DESCRIPTION
Just a typo fix -- right now the usage section is giving instructions for loading the old version of the library.
